### PR TITLE
Don't convert user sessions table

### DIFF
--- a/classes/Elgg/Upgrades/AlterDatabaseToMultiByteCharset.php
+++ b/classes/Elgg/Upgrades/AlterDatabaseToMultiByteCharset.php
@@ -22,7 +22,7 @@ class AlterDatabaseToMultiByteCharset {
 		'river',
 		'system_log',
 		'users_remember_me_cookies',
-		'users_sessions',
+		//'users_sessions',
 		'sites_entity',
 		'users_entity',
 		'objects_entity',


### PR DESCRIPTION
Converting the sessions table appears to cause some weird problems with system messages created during a logged out session being preserved, and continually echoed, in a logged in session.

Since sessions probably don't need mb4 support, don't convert them.